### PR TITLE
Changes Equal to check using .Equals instead of !=

### DIFF
--- a/SharpUnit/Src/Assert.cs
+++ b/SharpUnit/Src/Assert.cs
@@ -355,7 +355,7 @@ namespace SharpUnit
         public static void Equal(Object wanted, Object got)
         {
             // If values not equal
-            if (wanted != got)
+            if (!wanted.Equals(got))
             {
                 // Test failed
                 throw new TestException("Expected " + wanted + ", Got " + got);
@@ -372,7 +372,7 @@ namespace SharpUnit
         public static void Equal(Object wanted, Object got, string msg)
         {
             // If values not equal
-            if (wanted != got)
+            if (!wanted.Equals(got))
             {
                 // Test failed
                 throw new TestException(msg);

--- a/SharpUnit/Src/Assert.cs
+++ b/SharpUnit/Src/Assert.cs
@@ -355,7 +355,7 @@ namespace SharpUnit
         public static void Equal(Object wanted, Object got)
         {
             // If values not equal
-            if (!wanted.Equals(got))
+			if (!object.Equals(wanted, got))
             {
                 // Test failed
                 throw new TestException("Expected " + wanted + ", Got " + got);
@@ -372,7 +372,7 @@ namespace SharpUnit
         public static void Equal(Object wanted, Object got, string msg)
         {
             // If values not equal
-            if (!wanted.Equals(got))
+			if (!object.Equals(wanted, got))
             {
                 // Test failed
                 throw new TestException(msg);

--- a/SharpUnitTest/Tests/Assert_Test.cs
+++ b/SharpUnitTest/Tests/Assert_Test.cs
@@ -221,6 +221,18 @@ namespace SharpUnitTest
             Assert.Equal(obj, 3);
         }
 
+		[UnitTest]
+		public void TestEqual_Obj_Null_NoParams()
+		{
+			// Test pass
+			Object obj = new Dummy();
+			Assert.Equal((object)null, null);
+
+			// Test fail
+			Assert.ExpectException(new TestException("Expected , Got " + obj.GetType()));
+			Assert.Equal(null, obj);
+		}
+
         [UnitTest]
         public void TestEqual_Obj()
         {


### PR DESCRIPTION
Checks value and not reference, which != does by default.

This makes it possible to check if two strings' values are
equal even if they are casted to objects and the reference
isn't the same.
According to the comment above the check, this should be
the preferred behavior.
