### PR TITLE
compile fix for UnitTest.cs

### DIFF
--- a/SharpUnit/Src/UnitTest.cs
+++ b/SharpUnit/Src/UnitTest.cs
@@ -9,7 +9,7 @@ using System;
 namespace SharpUnit
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class UnitTest : Attribute
+    public class UnitTest : System.Attribute
     {
         // Intentionally empty
     }


### PR DESCRIPTION
Wasn't able to compile UnitTest.cs in Unity, I was receiving the error:

```
Attribute `System.AttributeUsageAttribute' is only valid on classes derived from System.Attribute
```

This fixes that.
